### PR TITLE
Update input.json to fix control remapping

### DIFF
--- a/dist/Cores/obsidian.Druaga/input.json
+++ b/dist/Cores/obsidian.Druaga/input.json
@@ -1,6 +1,11 @@
 {
     "input": {
         "magic": "APF_VER_1",
-        "controllers": []
+        "controllers": [
+            {
+                "type": "default",
+                "mappings": []
+            }
+        ]
     }
 }


### PR DESCRIPTION
`Controls` is greyed out in the core settings. With this change controls can be remapped.